### PR TITLE
Extending the documentation of the errors library

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +25,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -6,5 +6,3 @@ labels: ''
 assignees: ''
 
 ---
-
-

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,44 +3,29 @@ name: CMake
 on: [push]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source 
-      # and build directories, but this is only available with CMake 3.13 and higher.  
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Dutils_build_tests=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Test
       working-directory: ${{runner.workspace}}/build/test
       shell: bash
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C $BUILD_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ script:
   - mkdir build && cd build
   - cmake ../. -Dutils_build_tests=ON
   - make && sudo make install
-  - cd test
-  - ctest
+  - ctest --output-on-failure
 
 
 ### Provide Code Coverage Reports ###
@@ -46,8 +45,7 @@ matrix:
         - mkdir build && cd build
         - cmake ../. -Dutils_coverage=ON
         - make && sudo make install
-        - cd test
-        - ctest
+        - ctest --output-on-failure
         - lcov --directory . --capture --output-file coverage.info
-        - lcov --remove coverage.info '*gtest*' '*/test/*' '/usr/*' --output-file coverage.info
+        - lcov --remove coverage.info '*gtest*' '*/test/*' '*/tests/*' '/usr/*' --output-file coverage.info
         - coveralls -r ../../. --l coverage.info -n

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
     CACHE PATH
     "Single directory for all executables.")
 
+include_directories(include/common-utils)
+
 
 ### Installation ###
 install(DIRECTORY include/common-utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(CommonUtilities VERSION 2.0.0)
 
 
 ### Options ###
-option(utils_build_tests "Build all unit tests in the test directory." OFF)
+option(utils_build_tests "Build all unit tests in the testing directories." OFF)
+option(utils_build_samples "Build all code samples in the samples directories." OFF)
 option(utils_coverage "Turn on coverage options for use with lcov, gcov, and/or coveralls." OFF)
 
 if (utils_coverage)
@@ -50,7 +51,18 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
     CACHE PATH
     "Single directory for all executables.")
 
+
+### Libraries / Executables ###
 include_directories(include/common-utils)
+
+## Sample Programs ##
+if (utils_build_samples)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/samples)
+
+    add_executable(fibonacciExample libs/errors/samples/fibonacciExample.cpp)
+
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+endif()
 
 
 ### Installation ###
@@ -87,5 +99,14 @@ if (utils_build_tests)
 
     include_directories(${GTEST_INCLUDE_DIRS})
 
-    add_subdirectory(test)
+    include(CTest)
+    include(GoogleTest)
+
+    enable_testing()
+
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/tests)
+
+    add_subdirectory(tests)
+
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 endif()

--- a/README.md
+++ b/README.md
@@ -35,15 +35,17 @@ The Common-Utilities project was designed to have as few external dependencies a
 
 - The Bourne Again SHell (bash) is required to use of any of the scripts. While other versions of bash may work, the lowest version of bash I have tested these scripts on is 3.2. Many, if not all, shell scripts in this repository are *not* compliant with the POSIX shell.
 
-- [GoogleTest](https://github.com/google/googletest) was used for the testing all the source code in the project. Building and running all these tests is optional and more information can be found in the testing section of [`docs/BUILD.md`](https://github.com/crdrisko/common-utilities/blob/master/docs/BUILD.md).
-
 ### Build Requirements
 
 - [CMake](https://cmake.org): Version 3.10.0 or higher. See the documentation in the [`docs/BUILD.md`](https://github.com/crdrisko/common-utilities/blob/master/docs/BUILD.md) file for specific instructions on installing the project.
 
+### Test Requirements
+
+- [GoogleTest](https://github.com/google/googletest) was used for the testing all the source code in the project. Building and running all these tests is optional and more information can be found in the testing section of [`docs/BUILD.md`](https://github.com/crdrisko/common-utilities/blob/master/docs/BUILD.md).
+
 ## Contributing
 
-Please read CONTRIBUTING.md for details on how you can become a contributor and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](https://github.com/crdrisko/common-utilities/blob/master/docs/CONTRIBUTING.md) for details on how you can become a contributor and the process for submitting pull requests to us.
 
 ## License
 

--- a/cmake/CMakeLists.txt.in
+++ b/cmake/CMakeLists.txt.in
@@ -9,4 +9,8 @@ ExternalProject_Add(${EXTERN_ARGS_PROJECT}-download
                     GIT_REPOSITORY    ${EXTERN_ARGS_REPOSITORY}
                     GIT_TAG           master
                     SOURCE_DIR        "${EXTERN_ARGS_PROJECT}-src"
-                    BINARY_DIR        "${EXTERN_ARGS_PROJECT}-build")
+                    BINARY_DIR        "${EXTERN_ARGS_PROJECT}-build"
+                    CONFIGURE_COMMAND ""
+                    BUILD_COMMAND     ""
+                    INSTALL_COMMAND   ""
+                    TEST_COMMAND      "")

--- a/cmake/CMakeLists.txt.in
+++ b/cmake/CMakeLists.txt.in
@@ -9,8 +9,4 @@ ExternalProject_Add(${EXTERN_ARGS_PROJECT}-download
                     GIT_REPOSITORY    ${EXTERN_ARGS_REPOSITORY}
                     GIT_TAG           master
                     SOURCE_DIR        "${EXTERN_ARGS_PROJECT}-src"
-                    BINARY_DIR        "${EXTERN_ARGS_PROJECT}-build"
-                    CONFIGURE_COMMAND ""
-                    BUILD_COMMAND     ""
-                    INSTALL_COMMAND   ""
-                    TEST_COMMAND      "")
+                    BINARY_DIR        "${EXTERN_ARGS_PROJECT}-build")

--- a/cmake/utility-functions.cmake
+++ b/cmake/utility-functions.cmake
@@ -43,10 +43,10 @@ function(UtilsNewTest)
     cmake_parse_arguments(TEST_ARGS "${options}" "${one_value_keywords}" "${multi_value_keywords}" ${ARGN})
 
     add_executable(test${TEST_ARGS_TESTNAME}
-                   ${TEST_ARGS_INTERIOR_DIRECTORY}/test${TEST_ARGS_TESTNAME}.cpp)
+                   ${CommonUtilities_SOURCE_DIR}/libs/${TEST_ARGS_INTERIOR_DIRECTORY}/tests/test${TEST_ARGS_TESTNAME}.cpp)
 
     target_link_libraries(test${TEST_ARGS_TESTNAME} ${GTEST_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
     gtest_discover_tests(test${TEST_ARGS_TESTNAME}
-                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_ARGS_INTERIOR_DIRECTORY})
+                         WORKING_DIRECTORY ${CommonUtilities_SOURCE_DIR}/libs/${TEST_ARGS_INTERIOR_DIRECTORY}/tests)
 endfunction()

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -15,17 +15,15 @@ By default, the project is installed in the `/usr/local` filesystem but can be c
 
 ## Testing
 
-With each library in the project (Errors, Math, etc.), I have strived to provide ~100% unit test coverage for all functions. These tests can be found in the [`root/test`](https://github.com/crdrisko/common-utilities/tree/master/test) directory but do not get built by default. To turn on the testing features of the repository, add the `utils_build_tests` flag to the CMake instructions as shown in the code below.
+With each library in the project (Errors, Math, etc.), I have strived to provide ~100% unit test coverage for all functions. These tests can be found in the `root/libs/libraryName/tests` directory but do not get built by default. To turn on the testing features of the repository, add the `utils_build_tests=ON` option to the CMake instructions as shown in the code below:
 
 ```bash
 ## Same steps as before ... ##
 cmake ../common-utilities/. -Dutils_build_tests=ON
 make && [sudo] make install
 
-## Testing occurs in a separate, dedicated directory ##
-cd test
+## Run the unit tests ##
 ctest --output-on-failure
-cd ../
 ```
 
 [GoogleTest](https://github.com/google/googletest), which is used as the unit test framework, will be installed as an external CMake project if the repository was not already found.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,9 +12,9 @@ If you are looking for a good way to contribute to the project, please:
 
 ## Reporting issues and suggesting new features
 
-If you find that the project is not working properly, please file a report using the [Bug Report template](https://github.com/crdrisko/common-utilities/issues/new?assignees=&labels=bug&template=bug_report.md&title=[BUG]). Should the template provided not suit your needs, feel free to make a [Custom Bug Report](https://github.com/crdrisko/common-utilities/issues/new/choose), but please label it accordingly.
+If you find that the project is not working properly, please file a report using the [Bug Report template](https://github.com/crdrisko/common-utilities/issues/new?assignees=&labels=bug&template=bug_report.md&title=[BUG]). Should the template provided not suit your needs, feel free to make a [Custom Bug Report](https://github.com/crdrisko/common-utilities/issues/new?assignees=&labels=&template=custom.md&title=), but please label it accordingly.
 
-We are happy to hear your ideas for how to further improve Common-Utilities, ensuring it suits your needs. Check the [Issues](https://github.com/crdrisko/common-utilities/issues) and see if others have submitted similar feedback. You can upvote existing feedback (using the thumbs up reaction/by commenting) or [submit a new suggestion](https://github.com/crdrisko/common-utilities/labels/feature).
+We are happy to hear your ideas for how to further improve Common-Utilities, ensuring it suits your needs. Check the [Issues](https://github.com/crdrisko/common-utilities/issues) and see if others have submitted similar feedback. You can upvote existing feedback (using the thumbs up reaction/by commenting) or [submit a new suggestion](https://github.com/crdrisko/common-utilities/issues/new?assignees=&labels=&template=feature_request.md&title=).
 
 We always look at upvoted items in [Issues](https://github.com/crdrisko/common-utilities/issues) when we decide what to work on next. We read the comments and we look forward to hearing your input.
 

--- a/docs/PRIMER.md
+++ b/docs/PRIMER.md
@@ -12,11 +12,13 @@ The libraries included in this repository include the following, and more inform
 
 - [Errors](https://github.com/crdrisko/common-utilities/blob/master/libs/errors/docs/errors.md)
 
-- [Files](https://github.com/crdrisko/common-utilities/blob/master/libs/files/docs/errors.md)
+- [Files](https://github.com/crdrisko/common-utilities/blob/master/libs/files/docs/files.md)
 
-- [Math](https://github.com/crdrisko/common-utilities/blob/master/libs/math/docs/errors.md)
+- [Math](https://github.com/crdrisko/common-utilities/blob/master/libs/math/docs/math.md)
 
-- [Strings](https://github.com/crdrisko/common-utilities/blob/master/libs/strings/docs/errors.md)
+- [Operations](https://github.com/crdrisko/common-utilities/blob/master/libs/operations/docs/operations.md)
+
+- [Strings](https://github.com/crdrisko/common-utilities/blob/master/libs/strings/docs/strings.md)
 
 The following tree diagram shows how a sample library, `library1`, would be organized in the API:
 
@@ -41,7 +43,7 @@ The following tree diagram shows how a sample library, `library1`, would be orga
             └── ...
 ```
 
-The `libs` directory contains information about the specific library, such as the documentation, example code samples, source code (if any), and unit tests. The `include/common-utils` is where the header files for the library are stored. Note that the `libraryName.hpp` file is the public API and should be included in a user's project. The files in the `libraryName` directory contain the internal implementation details and are subject to change without notice.
+The `libs` directory contains information about the specific library, such as the documentation, example code samples, source code (if any), and unit tests. The `include/common-utils` is where the header files for the library are stored. Note that the `libraryName.hpp` file serves as the public API of the library and should be `#include`'d in a user's project. The files in the `libraryName` directory contain the internal implementation details and are subject to change without notice.
 
 ## Bash Scripts
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Ex:
 
 ## Code style and formatting
 
-Attempt to match the surrounding code styling as much as possible. Check the [Contributors Style Guidelines section](https://github.com/crdrisko/common-utilities/blob/master/docs/CONTRIBUTING.md) for how to write your code. <!--and the [Contributors Code Formatting section](CONTRIBUTING.md#Code-formatting) for how to format your code.-->
+Attempt to match the surrounding code styling as much as possible. Check the [Contributors Style Guidelines section](https://github.com/crdrisko/common-utilities/blob/master/docs/CONTRIBUTING.md#Style-guidelines) for how to write your code. <!--and the [Contributors Code Formatting section](https://github.com/crdrisko/common-utilities/blob/master/docs/CONTRIBUTING.md#Code-formatting) for how to format your code.-->
 
 ### Closing Issues
 

--- a/include/common-utils/errors/exceptions/fatalException.hpp
+++ b/include/common-utils/errors/exceptions/fatalException.hpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Cody R. Drisko. All rights reserved.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 //
-// Name: fatalException.hpp - Version 2.0.1
+// Name: fatalException.hpp - Version 2.0.0
 // Author: crdrisko
 // Date: 04/07/2020-11:09:24
 // Description: Defines a specialized exception handling class designed around the error utilities
@@ -11,8 +11,8 @@
 
 #include <exception>
 
-#include "../utils/errorHandling.hpp"
-#include "../utils/errorTypes.hpp"
+#include "errors/utils/errorHandling.hpp"
+#include "errors/utils/errorTypes.hpp"
 
 namespace CommonUtilities::Errors
 {
@@ -27,11 +27,9 @@ namespace CommonUtilities::Errors
     public:
         explicit FatalException(const ErrorMessage& Error) : error{Error}
         {
+            // This specific error is always fatal but needs to override the current exception that was thrown
             if ( error.programName.empty() || error.message.empty() )
-            {
-                // This specific error is always fatal but needs to override the current exception that was thrown
                 printFatalErrorMessage("Common-Utilities", "Program name and error message must be set.");
-            }
         }
 
         // Delegate our exception handling to the error handling classes

--- a/include/common-utils/errors/exceptions/fileNotFoundException.hpp
+++ b/include/common-utils/errors/exceptions/fileNotFoundException.hpp
@@ -12,8 +12,8 @@
 #include <string>
 #include <string_view>
 
-#include "fatalException.hpp"
-#include "../utils/errorTypes.hpp"
+#include "errors/exceptions/fatalException.hpp"
+#include "errors/utils/errorTypes.hpp"
 
 namespace CommonUtilities::Errors
 {

--- a/include/common-utils/errors/exceptions/invalidInputException.hpp
+++ b/include/common-utils/errors/exceptions/invalidInputException.hpp
@@ -11,8 +11,8 @@
 
 #include <string_view>
 
-#include "fatalException.hpp"
-#include "../utils/errorTypes.hpp"
+#include "errors/exceptions/fatalException.hpp"
+#include "errors/utils/errorTypes.hpp"
 
 namespace CommonUtilities::Errors
 {

--- a/include/common-utils/errors/traits/isFatal.hpp
+++ b/include/common-utils/errors/traits/isFatal.hpp
@@ -1,29 +1,25 @@
 // Copyright (c) 2020 Cody R. Drisko. All rights reserved.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 //
-// Name: isFatal.hpp - Version 2.0.1
+// Name: isFatal.hpp - Version 2.0.0
 // Author: crdrisko
 // Date: 08/26/2020-14:26:29
-// Description: Type traits used specifically for error and exception handing
+// Description: Type trait used to determine whether a given ErrorSeverity is fatal or not
 
 #ifndef COMMON_UTILITIES_ISFATAL_HPP
 #define COMMON_UTILITIES_ISFATAL_HPP
 
-#include "../utils/errorTypes.hpp"
+#include <type_traits>
+
+#include "errors/utils/errorTypes.hpp"
 
 namespace CommonUtilities::Errors
 {
     template<ErrorSeverity Severity>
-    struct IsFatalT
-    {
-        static constexpr bool value = false;
-    };
+    struct IsFatalT : std::false_type {};
 
     template<>
-    struct IsFatalT<ErrorSeverity::Fatal>
-    {
-        static constexpr bool value = true;
-    };
+    struct IsFatalT<ErrorSeverity::Fatal> : std::true_type {};
 
     template<ErrorSeverity Severity>
     constexpr bool isFatal = IsFatalT<Severity>::value;

--- a/include/common-utils/errors/utils/errorHandling.hpp
+++ b/include/common-utils/errors/utils/errorHandling.hpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Cody R. Drisko. All rights reserved.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 //
-// Name: errorHandling.hpp - Version 2.0.1
+// Name: errorHandling.hpp - Version 2.0.0
 // Author: cdrisko
 // Date: 01/31/2020-15:38:03
 // Description: Utilities for printing error messages according to an error's severity
@@ -13,8 +13,8 @@
 #include <iostream>
 #include <string_view>
 
-#include "errorTypes.hpp"
-#include "../traits/isFatal.hpp"
+#include "errors/utils/errorTypes.hpp"
+#include "errors/traits/isFatal.hpp"
 
 namespace CommonUtilities::Errors
 {
@@ -31,8 +31,8 @@ namespace CommonUtilities::Errors
     }
 
     // A convenience function for printing a error message for a fatal error
-    constexpr auto printFatalErrorMessage 
-        = [](std::string_view programName, std::string_view message) 
+    constexpr auto printFatalErrorMessage
+        = [](std::string_view programName, std::string_view message)
             -> void { printErrorMessage<ErrorSeverity::Fatal>(programName, message); };
 }
 

--- a/libs/errors/docs/errors.md
+++ b/libs/errors/docs/errors.md
@@ -36,3 +36,20 @@ The `printErrorMessage()` function template is a helper function for the `FatalE
 **Working Example:**
 
 For working examples of how to use the library, refer to the [testing](https://github.com/crdrisko/common-utilities/tree/master/libs/errors/tests) files or the [samples](https://github.com/crdrisko/common-utilities/tree/master/libs/errors/samples) directory, which together provide a comprehensive overview of the library's usage.
+
+To build and run the code samples for the error library, one should include the `utils_build_samples=ON` option to the CMake instructions. Similarly, to build and run the unit tests for the individual error functions, one should include the `utils_build_tests=ON` option, as shown in the code below:
+
+```bash
+cmake ../common-utilities/. -Dutils_build_samples=ON -Dutils_build_tests=ON
+make
+
+## Run error library samples ##
+cd bin/samples
+./fibonacciExample
+
+## Run error library unit tests ##
+cd ../tests
+./testAllErrorFunctions
+```
+
+*NOTE: the samples and tests will not be installed with the rest of the library. They exist only to extend the documentation and help the user navigate the library.*

--- a/libs/errors/docs/errors.md
+++ b/libs/errors/docs/errors.md
@@ -1,0 +1,38 @@
+# Errors
+
+The error handling library of the Common-Utilities project consists of functions and classes dedicated to error and exception handling. Since these types of events occur in virtually every project imaginable, it has proved useful collecting these functions in a single place.
+
+**Getting Started:**
+
+The following lines of code can be included in any user project to provide access to the errors library:
+
+```C++
+#include <common-utils/errors.hpp>
+
+using namespace CommonUtilities::Errors;
+```
+
+**Exception Handling:**
+
+This library provides an exception handling class: `CommonUtilities::Errors::FatalException` which derives from `std::exception`. Some other commonly used exceptions can also be found, all of which derive from this `FatalException` class. Because these exceptions derive from `std::exception` (either directly or indirectly), they can be caught by statements like the following:
+
+```C++
+catch (const std::exception& e)
+{
+    std::cerr << e.what() << std::endl;
+}
+```
+
+However, if we throw an additional `FatalException` in this catch block (see [example](https://github.com/crdrisko/common-utilities/tree/master/libs/errors/samples/fibonacciExample.cpp)), we can customize the error messages and handle the exception based on whether it is fatal or not. The information we throw, via our `FatalException` constructor, includes the name of the program where the exception originated, and of course, the error message itself.
+
+The `FatalException` class delegates its error handling to a separate utility function (discussed next) when the user invokes `handleErrorWithMessage()`. Because this exception type is deemed fatal, a verbose error message will be printed and `std::exit()` will be called.
+
+**Error Handling Utilities:**
+
+In the way of error handling, the Common-Utilities project defines two types of error severity: Warning and Fatal. These designations are defined as an enum class, `ErrorSeverity`, and are used to template the main function responsible for handling errors. Some type traits are provided as well which allow for compile-time determination of the level of severity our functions are dealing with. Some convenience type aliases and lambda functions are also defined to enhance code readability.
+
+The `printErrorMessage()` function template is a helper function for the `FatalException` class but can be called directly if needed. Depending on the error severity, the function will either print a warning to STDERR or print the supplied message and exit. `printFatalErrorMessage()` exists as a convience function for a fatal error so template parameters don't need to be explicitly writen.
+
+**Working Example:**
+
+For working examples of how to use the library, refer to the [testing](https://github.com/crdrisko/common-utilities/tree/master/libs/errors/tests) files or the [samples](https://github.com/crdrisko/common-utilities/tree/master/libs/errors/samples) directory, which together provide a comprehensive overview of the library's usage.

--- a/libs/errors/samples/fibonacciExample.cpp
+++ b/libs/errors/samples/fibonacciExample.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: fibonacciExample.cpp - Version 2.0.0
+// Author: crdrisko
+// Date: 09/01/2020-12:36:23
+// Description: An example of how to throw, catch, and rethrow any std::exception-derived exceptions for helpful error handling
+
+#include <cstddef>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <common-utils/errors.hpp>
+
+void printNFibonacciNumbers(std::size_t n);
+
+int main()
+{
+    try
+    {
+        try
+        {
+            for (std::size_t i {1}; i <= 125; i *= 5)
+            {
+                std::cout << std::setw(5) << i << "): ";
+                printNFibonacciNumbers(i);
+            }
+        }
+        catch (const std::exception& except)
+        {
+            CommonUtilities::Errors::ErrorMessage error;
+            error.programName = "Common-Utilities";
+            error.message = "Exception message: " + std::string{except.what()};
+
+            throw CommonUtilities::Errors::FatalException(error);
+        }
+    }
+    catch (const CommonUtilities::Errors::FatalException& except)
+    {
+        except.handleErrorWithMessage();
+    }
+}
+
+void printNFibonacciNumbers(std::size_t n)
+{
+
+    std::vector<std::size_t> fibonacciNumbers;
+
+    // Don't want to overshoot our data type, based on std::numeric_limits<std::size_t>::max()
+    if (std::size_t maxNAllowed {94}; n > maxNAllowed)
+        throw CommonUtilities::Errors::InvalidInputException("Common-Utilities",
+            "This value of n yields a fibonacci number too large for std::size_t to hold.");
+
+    for (std::size_t i {}; i < n; ++i)
+    {
+        if (i <= 1)
+            fibonacciNumbers.push_back(i);
+        else
+            fibonacciNumbers.push_back(fibonacciNumbers[i - 2] + fibonacciNumbers[i - 1]);
+
+        std::cout << fibonacciNumbers[i] << " ";
+    }
+
+    std::cout << std::endl;
+}

--- a/libs/errors/tests/testAllErrorFunctions.cpp
+++ b/libs/errors/tests/testAllErrorFunctions.cpp
@@ -8,11 +8,11 @@
 
 #include <gtest/gtest.h>
 
-#include "TestExceptions/testCommonExceptionTypes.hpp"
-#include "TestExceptions/testExceptionHandling.hpp"
-#include "TestTraits/testErrorTraits.hpp"
-#include "TestUtilities/testErrorHandling.hpp"
-#include "TestUtilities/testErrorTypes.hpp"
+#include "testExceptions/testCommonExceptionTypes.hpp"
+#include "testExceptions/testExceptionHandling.hpp"
+#include "testTraits/testErrorTraits.hpp"
+#include "testUtilities/testErrorHandling.hpp"
+#include "testUtilities/testErrorTypes.hpp"
 
 int main(int argc, char** argv)
 {

--- a/libs/errors/tests/testExceptions/testCommonExceptionTypes.hpp
+++ b/libs/errors/tests/testExceptions/testCommonExceptionTypes.hpp
@@ -1,17 +1,17 @@
 // Copyright (c) 2020 Cody R. Drisko. All rights reserved.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 //
-// Name: testCommonExceptionTypes.hpp - Version 2.0.1
+// Name: testCommonExceptionTypes.hpp - Version 2.0.0
 // Author: crdrisko
 // Date: 08/27/2020-12:15:18
 // Description: Provides ~100% unit test coverage over all specialty exception handling classes
 
-#ifndef TESTCOMMONEXCEPTIONTYPES_HPP
-#define TESTCOMMONEXCEPTIONTYPES_HPP
+#ifndef COMMON_UTILITIES_TESTING_TESTCOMMONEXCEPTIONTYPES_HPP
+#define COMMON_UTILITIES_TESTING_TESTCOMMONEXCEPTIONTYPES_HPP
 
 #include <gtest/gtest.h>
 
-#include "../../../include/common-utils/errors.hpp"
+#include "errors.hpp"
 
 using namespace CommonUtilities::Errors;
 
@@ -45,7 +45,7 @@ GTEST_TEST(testCommonExceptionTypes, invalidInputExceptionResultsInProgramTermin
     }, "Common-Utilities Fatal Error:\n\tThe user-supplied input is invalid.\n");
 }
 
-GTEST_TEST(testErrorFunctions, invalidInputExceptionPrintsNonDefaultMessage)
+GTEST_TEST(testCommonExceptionTypes, invalidInputExceptionPrintsNonDefaultMessage)
 {
     ASSERT_DEATH(
     {
@@ -60,7 +60,7 @@ GTEST_TEST(testErrorFunctions, invalidInputExceptionPrintsNonDefaultMessage)
     }, "Common-Utilities Fatal Error:\n\tLet's throw a fatal error.\n");
 }
 
-GTEST_TEST(testErrorFunctions, catchSpecializedExceptionsWithSpecializations)
+GTEST_TEST(testCommonExceptionTypes, catchSpecializedExceptionsWithSpecializations)
 {
     InvalidInputException exception1 {"Common-Utilities", "Let's throw a fatal error."};
     FileNotFoundException exception2 {"Common-Utilities", "test.cpp"};

--- a/libs/errors/tests/testExceptions/testExceptionHandling.hpp
+++ b/libs/errors/tests/testExceptions/testExceptionHandling.hpp
@@ -6,8 +6,8 @@
 // Date: 08/27/2020-12:07:48
 // Description: Provides ~100% unit test coverage over all exception handing functions
 
-#ifndef TESTEXCEPTIONHANDLING_HPP
-#define TESTEXCEPTIONHANDLING_HPP
+#ifndef COMMON_UTILITIES_TESTING_TESTEXCEPTIONHANDLING_HPP
+#define COMMON_UTILITIES_TESTING_TESTEXCEPTIONHANDLING_HPP
 
 #include <exception>
 #include <iostream>
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include "../../../include/common-utils/errors.hpp"
+#include "errors.hpp"
 
 using namespace CommonUtilities::Errors;
 

--- a/libs/errors/tests/testTraits/testErrorTraits.hpp
+++ b/libs/errors/tests/testTraits/testErrorTraits.hpp
@@ -1,17 +1,17 @@
 // Copyright (c) 2020 Cody R. Drisko. All rights reserved.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 //
-// Name: testErrorTraits.hpp - Version 2.0.1
+// Name: testErrorTraits.hpp - Version 2.0.0
 // Author: crdrisko
 // Date: 08/26/2020-14:36:00
 // Description: Provides ~100% unit test coverage over all type traits associated with error and exception handling
 
-#ifndef TESTERRORTRAITS_HPP
-#define TESTERRORTRAITS_HPP
+#ifndef COMMON_UTILITIES_TESTING_TESTERRORTRAITS_HPP
+#define COMMON_UTILITIES_TESTING_TESTERRORTRAITS_HPP
 
 #include <gtest/gtest.h>
 
-#include "../../../include/common-utils/errors.hpp"
+#include "errors.hpp"
 
 using namespace CommonUtilities::Errors;
 

--- a/libs/errors/tests/testUtilities/testErrorHandling.hpp
+++ b/libs/errors/tests/testUtilities/testErrorHandling.hpp
@@ -6,14 +6,14 @@
 // Date: 08/26/2020-14:35:44
 // Description: Provides ~100% unit test coverage over all error handing functions
 
-#ifndef TESTERRORHANDLING_HPP
-#define TESTERRORHANDLING_HPP
+#ifndef COMMON_UTILITIES_TESTING_TESTERRORHANDLING_HPP
+#define COMMON_UTILITIES_TESTING_TESTERRORHANDLING_HPP
 
 #include <string>
 
 #include <gtest/gtest.h>
 
-#include "../../../include/common-utils/errors.hpp"
+#include "errors.hpp"
 
 using namespace CommonUtilities::Errors;
 

--- a/libs/errors/tests/testUtilities/testErrorTypes.hpp
+++ b/libs/errors/tests/testUtilities/testErrorTypes.hpp
@@ -6,12 +6,12 @@
 // Date: 08/26/2020-15:02:42
 // Description: Provides ~100% unit test coverage over all error types and associated functions
 
-#ifndef TESTERRORTYPES_HPP
-#define TESTERRORTYPES_HPP
+#ifndef COMMON_UTILITIES_TESTING_TESTERRORTYPES_HPP
+#define COMMON_UTILITIES_TESTING_TESTERRORTYPES_HPP
 
 #include <gtest/gtest.h>
 
-#include "../../../include/common-utils/errors.hpp"
+#include "errors.hpp"
 
 using namespace CommonUtilities::Errors;
 

--- a/scripts/changeCase.sh
+++ b/scripts/changeCase.sh
@@ -2,7 +2,7 @@
 # Copyright (c) 2020 Cody R. Drisko. All rights reserved.
 # Licensed under the MIT License. See the LICENSE file in the project root for more information.
 #
-# Name: changeCase.sh - Version 1.0.2
+# Name: changeCase.sh - Version 1.0.3
 # Author: crdrisko
 # Date: 01/31/2020-14:45:49
 # Description: Script to change the case of an input string
@@ -23,8 +23,8 @@ printHelpMessage()      #@ DESCRIPTION: Print the changeCase program's help mess
     printf "EXAMPLE: changeCase -f -l -w LOWERCASE\n\n"
 }
 
-to_upper()		        #@ DESCRIPTION: Convert the first letter of a word to uppercase
-{				        #@ USAGE: to_upper sTRING
+to_upper()              #@ DESCRIPTION: Convert the first letter of a word to uppercase
+{                       #@ USAGE: to_upper sTRING
     unset _UPR
     unset UPWORD
 
@@ -45,8 +45,8 @@ to_upper()		        #@ DESCRIPTION: Convert the first letter of a word to upperc
     fi
 }
 
-upword()		        #@ DESCRIPTION: Convert the entire word to uppercase
-{				        #@ USAGE: upword string
+upword()                #@ DESCRIPTION: Convert the entire word to uppercase
+{                       #@ USAGE: upword string
     unset _UPWORD
     unset UPWORD
     local Word=$1
@@ -65,8 +65,8 @@ upword()		        #@ DESCRIPTION: Convert the entire word to uppercase
     fi
 }
 
-to_lower()		        #@ DESCRIPTION: Convert the first letter of a word to lowercase
-{				        #@ USAGE: to_lower String
+to_lower()              #@ DESCRIPTION: Convert the first letter of a word to lowercase
+{                       #@ USAGE: to_lower String
     unset _LWR
     unset LOWWORD
 
@@ -87,8 +87,8 @@ to_lower()		        #@ DESCRIPTION: Convert the first letter of a word to lowerc
     fi
 }
 
-lowword()		        #@ DESCRIPTION: Convert the entire word to lowercase
-{				        #@ USAGE: lowword STRING
+lowword()               #@ DESCRIPTION: Convert the entire word to lowercase
+{                       #@ USAGE: lowword STRING
     unset _LOWWORD
     unset LOWWORD
     local Word=$1

--- a/scripts/compiler.sh
+++ b/scripts/compiler.sh
@@ -2,7 +2,7 @@
 # Copyright (c) 2020 Cody R. Drisko. All rights reserved.
 # Licensed under the MIT License. See the LICENSE file in the project root for more information.
 #
-# Name: compiler.sh - Version 1.0.1
+# Name: compiler.sh - Version 1.0.2
 # Author: crdrisko
 # Date: 01/31/2020-14:46:06
 # Description: Collects the .cpp files in a directory and compiles them using g++
@@ -25,8 +25,8 @@ printHelpMessage()      #@ DESCRIPTION: Print the compiler program's help messag
     printf "EXAMPLE: compiler -i ../example.cpp -o example.out -V 20\n\n"
 }
 
-validVersion()		    #@ DESCRIPTION: Checks entered C++ version against released versions
-{					    #@ USAGE: validVersion INT
+validVersion()          #@ DESCRIPTION: Checks entered C++ version against released versions
+{                       #@ USAGE: validVersion INT
     case $1 in
         98) return 0 ;;  03) return 0 ;;  11) return 0 ;;
         14) return 0 ;;  17) return 0 ;;  20) return 0 ;;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,13 +6,16 @@ enable_testing()
 
 ## Tests ##
 UtilsNewTest(TESTNAME AllErrorFunctions
-             INTERIOR_DIRECTORY TestErrors)
+             INTERIOR_DIRECTORY errors)
 
-UtilsNewTest(TESTNAME FileFunctions
-             INTERIOR_DIRECTORY TestFiles)
+# UtilsNewTest(TESTNAME AllFileFunctions
+#              INTERIOR_DIRECTORY files)
 
-UtilsNewTest(TESTNAME MathFunctions
-             INTERIOR_DIRECTORY TestMath)
+# UtilsNewTest(TESTNAME AllMathFunctions
+#              INTERIOR_DIRECTORY math)
 
-UtilsNewTest(TESTNAME StringFunctions
-             INTERIOR_DIRECTORY TestStrings)
+# UtilsNewTest(TESTNAME AllOperationFunctions
+#              INTERIOR_DIRECTORY operations)
+
+# UtilsNewTest(TESTNAME AllStringFunctions
+#              INTERIOR_DIRECTORY strings)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,4 @@
-### Unit Testing ###
-include(CTest)
-include(GoogleTest)
-
-enable_testing()
-
-## Tests ##
+### Unit Tests ###
 UtilsNewTest(TESTNAME AllErrorFunctions
              INTERIOR_DIRECTORY errors)
 


### PR DESCRIPTION
# Pull Request Template for Common-Utilities

## Proposed changes

- Extend the documentation by separating supporting documents into a separate directory within the library
- Add project samples for better documentation than the unit tests can generally provide 
- Update some of the formatting and organizational pieces of the repository and build system

## Motivation behind changes

As mentioned in the issue, the documentation for each individual library up to this point was lacking. Here we add documentation both in plain writing through the use of markdown files and in code examples through sample programs. These changes, along with the changes to come should increase the readability and usability of the repository as a whole.

### Test plan

As always, the code is ~100% covered by unit tests. After building the project using `cmake`, tests can be ran using `ctest` as shown with the below commands. Additionally, short example programs have been included to demonstrate proper usage of the library. These samples can also be built with `cmake` and can be found in the `${PROJECT_BINARY_DIR}/bin/samples` directory.

```bash
cmake ../common-utilities/. -Dutils_build_samples=ON -Dutils_build_tests=ON
make

## Testing ##
ctest --output-on-failure

## Samples ##
cd bin/samples
./fibonacciExample
```

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](https://github.com/crdrisko/common-utilities/blob/master/docs/CONTRIBUTING.md).

- [x] I agree to contribute to the project under Common-Utilities' [MIT License](https://github.com/crdrisko/common-utilities/blob/master/LICENSE).

- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with Common-Utilities.

- [x] The PR is proposed to proper branch.

- [x] There is reference to original bug report and related work.

- [x] There is accuracy test, performance test and test data in the repository, if applicable.

- [x] The feature is well documented and sample code can be built with the project CMake.
