### PR TITLE
This closes #3 and closes #4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ if (utils_build_samples)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/samples)
 
     add_executable(fibonacciExample libs/errors/samples/fibonacciExample.cpp)
+    # add_executable(* libs/files/samples/*.cpp)
+    # add_executable(* libs/math/samples/*.cpp)
+    # add_executable(* libs/strings/samples/*.cpp)
+    # add_executable(* libs/utilities/samples/*.cpp)
 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 endif()
@@ -106,7 +110,7 @@ if (utils_build_tests)
 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/tests)
 
-    add_subdirectory(tests)
+    add_subdirectory(cmake/tests ${PROJECT_BINARY_DIR}/Testing)
 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if (utils_build_samples)
     # add_executable(* libs/files/samples/*.cpp)
     # add_executable(* libs/math/samples/*.cpp)
     # add_executable(* libs/strings/samples/*.cpp)
-    # add_executable(* libs/utilities/samples/*.cpp)
+    add_executable(comparableExample libs/utilities/samples/comparableExample.cpp)
 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 endif()

--- a/cmake/tests/CMakeLists.txt
+++ b/cmake/tests/CMakeLists.txt
@@ -8,8 +8,8 @@ UtilsNewTest(TESTNAME AllErrorFunctions
 # UtilsNewTest(TESTNAME AllMathFunctions
 #              INTERIOR_DIRECTORY math)
 
-# UtilsNewTest(TESTNAME AllOperationFunctions
-#              INTERIOR_DIRECTORY operations)
-
 # UtilsNewTest(TESTNAME AllStringFunctions
 #              INTERIOR_DIRECTORY strings)
+
+UtilsNewTest(TESTNAME AllUtilityFunctions
+             INTERIOR_DIRECTORY utilities)

--- a/include/common-utils/utilities.hpp
+++ b/include/common-utils/utilities.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: utilities.hpp - Version 1.0.0
+// Author: crdrisko
+// Date: 09/17/2020-12:35:51
+// Description: The public API for the Utility section of the Common-Utilities library.
+//   This header file should be included in all user programs using these utilities.
+//
+// Note: The internal implementation details associated with this API should not be used in any
+//   user program as they are subject to change at any time without warning.
+
+#ifndef COMMON_UTILITIES_UTILITIES_HPP
+#define COMMON_UTILITIES_UTILITIES_HPP
+
+#include "utilities/operators/comparisonOperators.hpp"
+#include "utilities/utils/potentiallyEmptyBaseClass.hpp"
+
+#endif

--- a/include/common-utils/utilities/operators/comparisonOperators.hpp
+++ b/include/common-utils/utilities/operators/comparisonOperators.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: comparisonOperators.hpp - Version 1.0.0
+// Author: crdrisko
+// Date: 09/17/2020-12:36:17
+// Description: An alternative to std::rel_opts which doesn't inject the comparison operators into the global namespace
+
+#ifndef COMMON_UTILITIES_COMPARISONOPERATORS_HPP
+#define COMMON_UTILITIES_COMPARISONOPERATORS_HPP
+
+#include "utilities/utils/potentiallyEmptyBaseClass.hpp"
+
+namespace CommonUtilities::Utilities
+{
+    template<typename Derived, typename Empty = PotentiallyEmptyBaseClass<Derived>>
+    class EqualityComparable : public Empty
+    {
+    public:
+        constexpr friend bool operator!=(const Derived& x1, const Derived& x2) { return !(x1 == x2); }
+    };
+
+    template<typename Derived, typename Empty = PotentiallyEmptyBaseClass<Derived>>
+    class LessThanComparable : public Empty
+    {
+    public:
+        constexpr friend bool operator>(const Derived& x1, const Derived& x2) { return x2 < x1; }
+        constexpr friend bool operator<=(const Derived& x1, const Derived& x2) { return !(x2 < x1); }
+        constexpr friend bool operator>=(const Derived& x1, const Derived& x2) { return !(x1 < x2);}
+    };
+
+    /* Note: if we were to inherit both EqualityComparable and LessThanComparable, we could be setting ourselves to
+        inhibit the EBCO. This way, if we do inherit an empty base class, our compiler can capitalize on that. */
+    template<typename Derived, typename Empty = PotentiallyEmptyBaseClass<Derived>>
+    class CompletelyComparable : public EqualityComparable<Derived, LessThanComparable<Derived, Empty>> {};
+}
+
+#endif

--- a/include/common-utils/utilities/utils/potentiallyEmptyBaseClass.hpp
+++ b/include/common-utils/utilities/utils/potentiallyEmptyBaseClass.hpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: potentiallyEmptyBaseClass.hpp - Version 1.0.0
+// Author: crdrisko
+// Date: 09/18/2020-08:53:09
+// Description: An empty base class to be used with other operators and/or operations
+
+#ifndef COMMON_UTILITIES_POTENTIALLYEMPTYBASECLASS_HPP
+#define COMMON_UTILITIES_POTENTIALLYEMPTYBASECLASS_HPP
+
+namespace CommonUtilities::Utilities
+{
+    /* Note: If we happen to inherit one of our operator classes but the required conditions aren't satisfied, or
+        the class is SFINAE'd away, we don't want to be left holding the (non-empty) bag. Thus, we can make use
+         of the Empty Base Class Optimization (EBCO) in all our operator classes to avoid these issues. */
+    template<typename>
+    class PotentiallyEmptyBaseClass {};
+}
+
+#endif

--- a/libs/errors/docs/errors.md
+++ b/libs/errors/docs/errors.md
@@ -2,7 +2,15 @@
 
 The error handling library of the Common-Utilities project consists of functions and classes dedicated to error and exception handling. Since these types of events occur in virtually every project imaginable, it has proved useful collecting these functions in a single place.
 
-**Getting Started:**
+## Table Of Contents
+
+- [Getting Started](#Getting-Started)
+- [Features](#Features)
+  - [Exception Handling](#Exception-Handling)
+  - [Error Handling Utilities](#Error-Handling-Utilities)
+- [Working Example](#Working-Example)
+
+## Getting Started
 
 The following lines of code can be included in any user project to provide access to the errors library:
 
@@ -12,7 +20,9 @@ The following lines of code can be included in any user project to provide acces
 using namespace CommonUtilities::Errors;
 ```
 
-**Exception Handling:**
+## Features
+
+### [Exception Handling](https://github.com/crdrisko/common-utilities/blob/master/include/common-utils/errors/exceptions)
 
 This library provides an exception handling class: `CommonUtilities::Errors::FatalException` which derives from `std::exception`. Some other commonly used exceptions can also be found, all of which derive from this `FatalException` class. Because these exceptions derive from `std::exception` (either directly or indirectly), they can be caught by statements like the following:
 
@@ -27,13 +37,13 @@ However, if we throw an additional `FatalException` in this catch block (see [ex
 
 The `FatalException` class delegates its error handling to a separate utility function (discussed next) when the user invokes `handleErrorWithMessage()`. Because this exception type is deemed fatal, a verbose error message will be printed and `std::exit()` will be called.
 
-**Error Handling Utilities:**
+### [Error Handling Utilities](https://github.com/crdrisko/common-utilities/blob/master/include/common-utils/errors/utils)
 
 In the way of error handling, the Common-Utilities project defines two types of error severity: Warning and Fatal. These designations are defined as an enum class, `ErrorSeverity`, and are used to template the main function responsible for handling errors. Some type traits are provided as well which allow for compile-time determination of the level of severity our functions are dealing with. Some convenience type aliases and lambda functions are also defined to enhance code readability.
 
 The `printErrorMessage()` function template is a helper function for the `FatalException` class but can be called directly if needed. Depending on the error severity, the function will either print a warning to STDERR or print the supplied message and exit. `printFatalErrorMessage()` exists as a convience function for a fatal error so template parameters don't need to be explicitly writen.
 
-**Working Example:**
+## Working Example
 
 For working examples of how to use the library, refer to the [testing](https://github.com/crdrisko/common-utilities/tree/master/libs/errors/tests) files or the [samples](https://github.com/crdrisko/common-utilities/tree/master/libs/errors/samples) directory, which together provide a comprehensive overview of the library's usage.
 
@@ -43,11 +53,11 @@ To build and run the code samples for the error library, one should include the 
 cmake ../common-utilities/. -Dutils_build_samples=ON -Dutils_build_tests=ON
 make
 
-## Run error library samples ##
+## Run the error library's samples ##
 cd bin/samples
 ./fibonacciExample
 
-## Run error library unit tests ##
+## Run the error library's unit tests ##
 cd ../tests
 ./testAllErrorFunctions
 ```

--- a/libs/errors/samples/fibonacciExample.cpp
+++ b/libs/errors/samples/fibonacciExample.cpp
@@ -15,6 +15,8 @@
 
 #include <common-utils/errors.hpp>
 
+using namespace CommonUtilities::Errors;
+
 void printNFibonacciNumbers(std::size_t n);
 
 int main()
@@ -31,14 +33,14 @@ int main()
         }
         catch (const std::exception& except)
         {
-            CommonUtilities::Errors::ErrorMessage error;
+            ErrorMessage error;
             error.programName = "Common-Utilities";
             error.message = "Exception message: " + std::string{except.what()};
 
-            throw CommonUtilities::Errors::FatalException(error);
+            throw FatalException(error);
         }
     }
-    catch (const CommonUtilities::Errors::FatalException& except)
+    catch (const FatalException& except)
     {
         except.handleErrorWithMessage();
     }
@@ -51,7 +53,7 @@ void printNFibonacciNumbers(std::size_t n)
 
     // Don't want to overshoot our data type, based on std::numeric_limits<std::size_t>::max()
     if (std::size_t maxNAllowed {94}; n > maxNAllowed)
-        throw CommonUtilities::Errors::InvalidInputException("Common-Utilities",
+        throw InvalidInputException("Common-Utilities",
             "This value of n yields a fibonacci number too large for std::size_t to hold.");
 
     for (std::size_t i {}; i < n; ++i)

--- a/libs/utilities/docs/utilities.md
+++ b/libs/utilities/docs/utilities.md
@@ -1,0 +1,42 @@
+# Utilities
+
+A brief summary of the library as a whole...
+
+**Getting Started:**
+
+The following lines of code can be included in any user project to provide access to the utilities library:
+
+```C++
+#include <common-utils/utilities.hpp>
+
+using namespace CommonUtilities::Utilities;
+```
+
+**Comparison Operators:**
+
+A brief summary of the comparison operators portion of the library...
+
+**Miscellaneous Utility Functions:**
+
+A brief summary of the utilities portion of the library...
+
+**Working Example:**
+
+For working examples of how to use the library, refer to the [testing](https://github.com/crdrisko/common-utilities/tree/master/libs/utilities/tests) files or the [samples](https://github.com/crdrisko/common-utilities/tree/master/libs/utilities/samples) directory, which together provide a comprehensive overview of the library's usage.
+
+To build and run the code samples for the utilities library, one should include the `utils_build_samples=ON` option to the CMake instructions. Similarly, to build and run the unit tests for the individual utility functions, one should include the `utils_build_tests=ON` option, as shown in the code below:
+
+```bash
+cmake ../common-utilities/. -Dutils_build_samples=ON -Dutils_build_tests=ON
+make
+
+## Run utility library's samples ##
+cd bin/samples
+./sampleName
+
+## Run utility library's unit tests ##
+cd ../tests
+./testAllUtilityFunctions
+```
+
+*NOTE: the samples and tests will not be installed with the rest of the library. They exist only to extend the documentation and help the user navigate the library.*

--- a/libs/utilities/docs/utilities.md
+++ b/libs/utilities/docs/utilities.md
@@ -1,8 +1,16 @@
 # Utilities
 
-A brief summary of the library as a whole...
+The utilities library consists of a number of miscellaneous functions and classes that either don't belong in one of the other libraries, don't have enough substance to warrant their own library, or exist only to assist other libraries in the project. I imagine as time goes on some of the modules within this library will spin-off into their own complete library, but for now this serves as a good place to collect them.
 
-**Getting Started:**
+## Table Of Contents
+
+- [Getting Started](#Getting-Started)
+- [Features](#Features)
+  - [Comparison Operators](#Comparison-Operators)
+  - [Miscellaneous Utilities](#Miscellaneous-Utilities)
+- [Working Example](#Working-Example)
+
+## Getting Started
 
 The following lines of code can be included in any user project to provide access to the utilities library:
 
@@ -12,15 +20,21 @@ The following lines of code can be included in any user project to provide acces
 using namespace CommonUtilities::Utilities;
 ```
 
-**Comparison Operators:**
+## Features
 
-A brief summary of the comparison operators portion of the library...
+### [Comparison Operators](https://github.com/crdrisko/common-utilities/blob/master/include/common-utils/utilities/operators)
 
-**Miscellaneous Utility Functions:**
+The comparison operators portion of the utilities library serves to provide a robust way of implementing all comparison operators in terms of the `==` and `<` operators. Similar to how you would go about using the [`std::rel_opts`](https://en.cppreference.com/w/cpp/utility/rel_ops/operator_cmp), defining these two operators for your class gives you the remaining operators without having to hard code them yourself. The difference between the `CompletelyComparable<>` class template and `std::rel_opts` however, is that the `CompletelyComparable<>` class template when inherited via private inheritance, does not inject the additional operators into the global namespace. Rather we use friend functions and the curiously recurring template pattern (CRTP) to provide the limited interface we want.
 
-A brief summary of the utilities portion of the library...
+The other class templates, `EqualityComparable<>` and `LessThanComparable<>` aren't really designed to be used by the end user, but could be if really needed. Instead, they split the functionality up into logical components that when combined, give us the `CompletelyComparable<>` class. The `Empty` template parameter exists only to avoid inhibiting any optimizations (see below) the compiler may be able to make.
 
-**Working Example:**
+For a good example of a project implementing the operators afforded by the `CompletelyComparable<>` class, check out my other repo: [C++ Units](https://github.com/crdrisko/cpp-units.git), specifically the `PhysicalQuantity<>` class template. This class defines the comparison operators `operator==()` and `operator<()` then implements, via private inheritance, the rest of the comparison operators.
+
+### [Miscellaneous Utilities](https://github.com/crdrisko/common-utilities/blob/master/include/common-utils/utilities/utils)
+
+The empty base class optimization (EBCO) is an optimization strategy implemented by some compilers, which allows for empty classes deriving from other empty classes to contribute no additional memory. However, if two empty-base class derived classes are inherited by another class, this optimization is inhibited and both classes contribute to the memory. We can get around this by defining additional template parameters for potentially empty base classes, and use the curiously recurring template pattern (CRTP) in conjunction with the EBCO, to optimize, or rather let the compiler optimize, the traits and policies we intend to inherit. With this in mind, the `PotentiallyEmptyBaseClass<>` class template is a helper class for some of the operators and traits in the library. I don't imagine this class will get much use outside the repository but examples of where it is used can be found with the [Comparison Operators](#Comparison-Operators) above.
+
+## Working Example
 
 For working examples of how to use the library, refer to the [testing](https://github.com/crdrisko/common-utilities/tree/master/libs/utilities/tests) files or the [samples](https://github.com/crdrisko/common-utilities/tree/master/libs/utilities/samples) directory, which together provide a comprehensive overview of the library's usage.
 
@@ -30,11 +44,11 @@ To build and run the code samples for the utilities library, one should include 
 cmake ../common-utilities/. -Dutils_build_samples=ON -Dutils_build_tests=ON
 make
 
-## Run utility library's samples ##
+## Run the utility library's samples ##
 cd bin/samples
-./sampleName
+./comparableExample
 
-## Run utility library's unit tests ##
+## Run the utility library's unit tests ##
 cd ../tests
 ./testAllUtilityFunctions
 ```

--- a/libs/utilities/samples/comparableExample.cpp
+++ b/libs/utilities/samples/comparableExample.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: comparableExample.cpp - Version 1.0.0
+// Author: crdrisko
+// Date: 09/22/2020-09:06:16
+// Description: An example of how to use the CompletelyComparable<> class template when comparing fruits
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <common-utils/utilities.hpp>
+
+using namespace CommonUtilities::Utilities;
+
+class Fruit : private CompletelyComparable<Fruit>                   // Private inheritance for an 'implements a' relationship
+{
+private:
+    std::string name;
+    int rank;
+
+public:
+    enum class Rankings { Worst, PrettyGood, Great, Best };
+
+    Fruit(std::string_view Name, Rankings Rank) noexcept : name{Name}, rank{ static_cast<int>(Rank) } {}
+
+    friend bool operator==(const Fruit& lhs, const Fruit& rhs) noexcept { return lhs.rank == rhs.rank; }
+    friend bool operator<(const Fruit& lhs, const Fruit& rhs) noexcept { return lhs.rank < rhs.rank; }
+
+    std::string getName() const { return name; }
+};
+
+void printFruitComparisons(const std::vector<Fruit>& commonFruits);
+
+int main()
+{
+    Fruit apple      {"Apple",      Fruit::Rankings::Great};
+    Fruit banana     {"Banana",     Fruit::Rankings::PrettyGood};
+    Fruit orange     {"Orange",     Fruit::Rankings::PrettyGood};
+    Fruit pear       {"Pear",       Fruit::Rankings::Best};
+    Fruit watermelon {"Watermelon", Fruit::Rankings::Worst};
+
+    std::vector<Fruit> commonFruits {apple, banana, orange, pear, watermelon};
+
+    std::sort(commonFruits.begin(), commonFruits.end());
+    printFruitComparisons(commonFruits);
+
+    std::cout << std::endl;
+
+    std::sort(commonFruits.begin(), commonFruits.end(), std::greater<Fruit>());
+    printFruitComparisons(commonFruits);
+}
+
+void printFruitComparisons(const std::vector<Fruit>& commonFruits)
+{
+    for (std::size_t i {}; i < commonFruits.size(); ++i)
+    {
+        std::string fruitPrefix;
+        Fruit currentFruit = commonFruits[i];
+
+        switch ( std::tolower(currentFruit.getName()[0]) )
+        {
+        case 'a': case 'e': case 'i': case 'o': case 'u':
+            fruitPrefix = "an";
+            break;
+        default:
+            fruitPrefix = "a";
+            break;
+        }
+
+        if (i != 0)
+        {
+            Fruit previousFruit = commonFruits[i - 1];
+
+            if (previousFruit == currentFruit)
+                std::cout << " is as good as ";
+            else if (previousFruit > currentFruit)
+                std::cout << " is better than ";
+            else
+                std::cout << " is worse than ";
+
+            std::cout << fruitPrefix << ' ';
+        }
+        else
+            std::cout << static_cast<char>(std::toupper(fruitPrefix[0])) << ' ';
+
+        std::cout << currentFruit.getName();
+
+        if (i != 0 && i != commonFruits.size() - 1)
+            std::cout << ", which";
+    }
+
+    std::cout << std::endl;
+}

--- a/libs/utilities/tests/testAllUtilityFunctions.cpp
+++ b/libs/utilities/tests/testAllUtilityFunctions.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: testAllUtilityFunctions.cpp - Version 1.0.0
+// Author: crdrisko
+// Date: 09/18/2020-09:00:10
+// Description: Provides ~100% unit test coverage over all helper utility functions
+
+#include <gtest/gtest.h>
+
+#include "testOperators/testComparisonOperators.hpp"
+#include "testUtilities/testPotentiallyEmptyBaseClass.hpp"
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/libs/utilities/tests/testOperators/testComparisonOperators.hpp
+++ b/libs/utilities/tests/testOperators/testComparisonOperators.hpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: testComparisonOperators.hpp - Version 1.0.0
+// Author: crdrisko
+// Date: 09/18/2020-09:01:46
+// Description: Provides ~100% unit test coverage over all comparison operators
+
+#ifndef COMMON_UTILITIES_TESTING_TESTCOMPARISONOPERATORS_HPP
+#define COMMON_UTILITIES_TESTING_TESTCOMPARISONOPERATORS_HPP
+
+#include <gtest/gtest.h>
+
+#include "utilities.hpp"
+
+// Helper classes for testing
+namespace CommonUtilities::Utilities
+{
+    class SomewhatComparable1 : private EqualityComparable<SomewhatComparable1>
+    {
+    private:
+        int value;
+
+    public:
+        explicit SomewhatComparable1(int Value) noexcept : value{Value} {}
+
+        friend bool operator==(const SomewhatComparable1& lhs, const SomewhatComparable1& rhs) noexcept
+        {
+            return lhs.value == rhs.value;
+        }
+    };
+
+    class SomewhatComparable2 : private LessThanComparable<SomewhatComparable2>
+    {
+    private:
+        int value;
+
+    public:
+        explicit SomewhatComparable2(int Value) noexcept : value{Value} {}
+
+        friend bool operator<(const SomewhatComparable2& lhs, const SomewhatComparable2& rhs) noexcept
+        {
+            return lhs.value < rhs.value;
+        }
+    };
+
+    class Comparable : private CompletelyComparable<Comparable>
+    {
+    private:
+        int value;
+
+    public:
+        explicit Comparable(int Value) noexcept : value{Value} {}
+
+        friend bool operator==(const Comparable& lhs, const Comparable& rhs) noexcept
+        {
+            return lhs.value == rhs.value;
+        }
+
+        friend bool operator<(const Comparable& lhs, const Comparable& rhs) noexcept
+        {
+            return lhs.value < rhs.value;
+        }
+    };
+}
+
+using namespace CommonUtilities::Utilities;
+
+GTEST_TEST(testComparisonOperators, aClassThatInheritsFromEqualityComparableCanOnlyCallEqualityComparisons)
+{
+    SomewhatComparable1 value1 {5};
+    SomewhatComparable1 value2 {5};
+    SomewhatComparable1 value3 {10};
+
+    ASSERT_TRUE(value1 == value2);
+    ASSERT_FALSE(value1 == value3);
+
+    ASSERT_TRUE(value1 != value3);
+    ASSERT_FALSE(value1 != value2);
+
+    // ASSERT_TRUE(value1 < value3);                        // Error: no operator ">=" matches these operands
+}
+
+GTEST_TEST(testComparisonOperators, aClassThatInheritsFromLessThanComparableCanOnlyCallInequalityComparisons)
+{
+    SomewhatComparable2 value1 {5};
+    SomewhatComparable2 value2 {5};
+    SomewhatComparable2 value3 {10};
+
+    ASSERT_TRUE(value1 < value3);
+    ASSERT_FALSE(value1 < value2);
+
+    ASSERT_TRUE(value3 > value2);
+    ASSERT_FALSE(value1 > value2);
+
+    ASSERT_TRUE(value1 <= value2);
+    ASSERT_FALSE(value3 <= value2);
+
+    ASSERT_TRUE(value3 >= value2);
+    ASSERT_FALSE(value1 >= value3);
+
+    // ASSERT_TRUE(value1 == value2);                       // Error: no operator "==" matches these operands
+}
+
+GTEST_TEST(testComparisonOperators, aClassThatInheritsFromCompletelyComparableCanCallAllComparisons)
+{
+    Comparable value1 {5};
+    Comparable value2 {5};
+    Comparable value3 {10};
+
+    ASSERT_TRUE(value1 == value2);
+    ASSERT_FALSE(value1 == value3);
+
+    ASSERT_TRUE(value1 != value3);
+    ASSERT_FALSE(value1 != value2);
+
+    ASSERT_TRUE(value1 < value3);
+    ASSERT_FALSE(value1 < value2);
+
+    ASSERT_TRUE(value3 > value2);
+    ASSERT_FALSE(value1 > value2);
+
+    ASSERT_TRUE(value1 <= value2);
+    ASSERT_FALSE(value3 <= value2);
+
+    ASSERT_TRUE(value3 >= value2);
+    ASSERT_FALSE(value1 >= value3);
+}
+
+#endif

--- a/libs/utilities/tests/testUtilities/testPotentiallyEmptyBaseClass.hpp
+++ b/libs/utilities/tests/testUtilities/testPotentiallyEmptyBaseClass.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Cody R. Drisko. All rights reserved.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+//
+// Name: testPotentiallyEmptyBaseClass.hpp - Version 1.0.0
+// Author: crdrisko
+// Date: 09/18/2020-09:02:30
+// Description: Provides ~100% unit test coverage over the potentially empty base class utility
+
+#ifndef COMMON_UTILITIES_TESTING_TESTPOTENTIALLYEMPTYBASECLASS_HPP
+#define COMMON_UTILITIES_TESTING_TESTPOTENTIALLYEMPTYBASECLASS_HPP
+
+#include <gtest/gtest.h>
+
+#include "utilities.hpp"
+
+// Helper classes for testing
+namespace CommonUtilities::Utilities
+{
+    // The EBCO and CRTP used together for an empty class
+    class EmptyDerived : public PotentiallyEmptyBaseClass<EmptyDerived> {};
+}
+
+using namespace CommonUtilities::Utilities;
+
+GTEST_TEST(testPotentiallyEmptyBaseClass, anEmptyBaseClassHasANonZeroSize)
+{
+    ASSERT_TRUE(sizeof(PotentiallyEmptyBaseClass<bool>) > 0);
+}
+
+GTEST_TEST(testPotentiallyEmptyBaseClass, ebcoCouldBeUsedToMinimizeTheSizeOfADerivedEmptyClass)
+{
+    ASSERT_TRUE(sizeof(PotentiallyEmptyBaseClass<EmptyDerived>) <= sizeof(EmptyDerived));
+
+    // The two should be equal if the compiler implements the EBCO, uncomment the following to find out for your compiler:
+    // ASSERT_TRUE(sizeof(PotentiallyEmptyBaseClass<EmptyDerived>) <= sizeof(EmptyDerived));
+}
+
+#endif


### PR DESCRIPTION
# Pull Request Template for Common-Utilities

## Proposed changes

- The file `tests/CMakeLists.txt` was moved to `cmake/tests/CMakeLists.txt` and included as a sub_directory to remove an otherwise unnecessary directory, thereby satisfactorily closing issue #3.
- A new library was created for housing miscellaneous utilities that don't have enough features for a library of their own.
- This library was initialized with a number of class templates dedicated to providing a more reliable way of defining comparison operators for a user-defined class than `std::rel_opts`.

## Motivation behind changes

As mentioned in the issues, the `tests` directory was obsolete and unnecessary. The required functionality could be moved to a non-obsolete directory, allowing us to remove `tests` entirely. The next portion of this pull request adds a new feature library to the repository called utilities. This library contains only features relating to comparison operators yet will serve as a home for additional features as they are added-in in subsequent releases.

### Test plan

As always, the code is ~100% covered by unit tests. After building the project using cmake, tests can be ran using ctest as shown with the below commands. Additionally, short example programs have been included to demonstrate proper usage of the library. These samples can also be built with cmake and can be found in the ${PROJECT_BINARY_DIR}/bin/samples directory.

```bash
cmake ../common-utilities/. -Dutils_build_samples=ON -Dutils_build_tests=ON
make

## Testing ##
ctest --output-on-failure

## Samples ##
cd bin/samples
./comparableExample.cpp
```

### Pull Request Readiness Checklist

See details at [CONTRIBUTING.md](https://github.com/crdrisko/common-utilities/blob/master/docs/CONTRIBUTING.md).

- [x] I agree to contribute to the project under Common-Utilities' [MIT License](https://github.com/crdrisko/common-utilities/blob/master/LICENSE).

- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with Common-Utilities.

- [x] The PR is proposed to proper branch.

- [x] There is reference to original bug report and related work.

- [x] There is accuracy test, performance test and test data in the repository, if applicable.

- [x] The feature is well documented and sample code can be built with the project CMake.
